### PR TITLE
adding case for when the real object should be the function __proto__

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,7 +40,8 @@ module.exports = function(app) {
    */
 
   app.mixin('use', function(fn) {
-    var plugin = fn.call(this, this);
+    var thisArg = (typeof this === 'function' ? this.__proto__ : this);
+    var plugin = fn.call(thisArg, thisArg);
     if (typeof plugin === 'function') {
       this.plugins.push(plugin);
     }

--- a/index.js
+++ b/index.js
@@ -40,7 +40,10 @@ module.exports = function(app) {
    */
 
   app.mixin('use', function(fn) {
-    var thisArg = (typeof this === 'function' ? this.__proto__ : this);
+    var thisArg = this;
+    if (typeof this === 'function' && ('__proto__' in this)) {
+      thisArg = this.__proto__;
+    }
     var plugin = fn.call(thisArg, thisArg);
     if (typeof plugin === 'function') {
       this.plugins.push(plugin);

--- a/test.js
+++ b/test.js
@@ -132,5 +132,37 @@ describe('plugins', function() {
       assert(config.c === 'c');
       done();
     });
+
+    it('should call the `use` method on the function __proto__ passed to run:', function(done) {
+      base
+        .use(function() {
+          return function(config) {
+            config.a = 'a';
+          };
+        })
+        .use(function() {
+          return function(config) {
+            config.b = 'b';
+          };
+        })
+        .use(function() {
+          return function(config) {
+            config.c = 'c';
+          };
+        });
+
+      var config = new Base();
+      var fn = function () {};
+      fn.__proto__ = config;
+
+      base.run(fn);
+      assert(config.a === 'a');
+      assert(config.b === 'b');
+      assert(config.c === 'c');
+      assert(fn.a === 'a');
+      assert(fn.b === 'b');
+      assert(fn.c === 'c');
+      done();
+    });
   });
 });


### PR DESCRIPTION
This is happening when wanting to add methods to a view collection in `templates/assemble`:

``` js
app.pages.use(function (collection) {
  collection.foo = function (msg) {
    return 'foo ' + msg;
  };
});

app.pages.foo('bar');
```

This change fixes this by detecting when `this` is a function, use it's `__proto__`. This is better than requiring plugins to use `collection.mixin('foo')` because we don't always want to change the `Views` prototype.

@jonschlinkert let me know what you think or if there's something I might be missing. I added a test around this to make sure it's working.
